### PR TITLE
For use of Trezor 0.11.6 Module

### DIFF
--- a/contrib/requirements/requirements-hw.txt
+++ b/contrib/requirements/requirements-hw.txt
@@ -1,4 +1,4 @@
-trezor[hidapi]>=0.11.0
+trezor[hidapi]==0.11.6
 safet[hidapi]>=0.1.0
 keepkey>=6.0.3
 btchip-python>=0.1.26


### PR DESCRIPTION
Doesn't support the handling of passphrase for versions above this and I don't have the inclination to fix it...